### PR TITLE
Bump wallet version

### DIFF
--- a/funding/api.py
+++ b/funding/api.py
@@ -79,7 +79,9 @@ def api_wowlight_version_check(version):
     :return: bool
     """
     versions = {
-        '0.1.0': True
+        '0.1.0': False,
+        '0.1.1': False,
+        '0.1.2': True
     }
 
     if version not in versions:


### PR DESCRIPTION
Will make older versions of the light wallet prompt a message about outdated version.